### PR TITLE
Disable Travis cache to avoid bloat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-cache: cargo
 rust:
 - stable
 - nightly


### PR DESCRIPTION
Caching `cargo` output makes the build slower because the cache will increase in size at any new `nightly` release