### PR TITLE
Upgraded PyO3 to 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"
-pyo3 = "0.8.1"
+pyo3 = "~0.8.3"

--- a/tests/build/unsupported_into.stderr
+++ b/tests/build/unsupported_into.stderr
@@ -12,6 +12,3 @@ error[E0277]: the trait bound `pyo3::object::PyObject: pyo3::conversion::FromPy<
           and 4 others
   = note: required because of the requirements on the impl of `pyo3::conversion::IntoPy<pyo3::object::PyObject>` for `Test`
   = note: required by `pyo3::conversion::IntoPy::into_py`
-
-For more information about this error, try `rustc --explain E0277`.
-error: could not compile `dict_derive-tests`.


### PR DESCRIPTION
Fixes failures with the latest `nightly`