### PR TITLE
feat: print detailed error info if from fails

### DIFF
--- a/src/from.rs
+++ b/src/from.rs
@@ -42,8 +42,8 @@ fn map_extraction(field: Field) -> TokenStream {
 
 fn extraction_functions() -> TokenStream {
     quote! {
-        fn map_exception(name: &str, _: PyErr) -> PyErr {
-            PyErr::new::<PyTypeError, _>(format!("Unable to convert key: {}", name))
+        fn map_exception(name: &str, e: PyErr) -> PyErr {
+            PyErr::new::<PyTypeError, _>(format!("Unable to convert key: {}. Error: {}", name, e))
         }
 
         fn extract_required<'a, T>(dict: &'a PyDict, name: &str) -> PyResult<T>

--- a/tests/build/unsupported_from.stderr
+++ b/tests/build/unsupported_from.stderr
@@ -1,18 +1,18 @@
-error[E0277]: the trait bound `Test: PyClass` is not satisfied
- --> tests/build/unsupported_from.rs:9:11
+error[E0277]: the trait bound `Test: FromPyObject<'_>` is not satisfied
+ --> tests/build/unsupported_from.rs:9:5
   |
 9 |     test: Test,
-  |           ^^^^ the trait `PyClass` is not implemented for `Test`
+  |     ^^^^^^^^^^ the trait `PyClass` is not implemented for `Test`, which is required by `Test: FromPyObject<'_>`
   |
   = help: the following other types implement trait `FromPyObject<'source>`:
-            <bool as FromPyObject<'source>>
-            <char as FromPyObject<'_>>
-            <isize as FromPyObject<'source>>
-            <i8 as FromPyObject<'source>>
-            <i16 as FromPyObject<'source>>
-            <i32 as FromPyObject<'source>>
-            <i64 as FromPyObject<'source>>
-            <i128 as FromPyObject<'source>>
+            <&'a PyCell<T> as FromPyObject<'a>>
+            <&'a [u8] as FromPyObject<'a>>
+            <&'py CancelledError as FromPyObject<'py>>
+            <&'py IncompleteReadError as FromPyObject<'py>>
+            <&'py InvalidStateError as FromPyObject<'py>>
+            <&'py LimitOverrunError as FromPyObject<'py>>
+            <&'py PanicException as FromPyObject<'py>>
+            <&'py PyAny as FromPyObject<'py>>
           and $N others
   = note: required for `Test` to implement `FromPyObject<'_>`
 note: required by a bound in `extract_required`
@@ -22,21 +22,21 @@ note: required by a bound in `extract_required`
   |          ^^^^^^^^^^^^ required by this bound in `extract_required`
   = note: this error originates in the derive macro `FromPyObject` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Test: Clone` is not satisfied
- --> tests/build/unsupported_from.rs:9:11
+error[E0277]: the trait bound `Test: FromPyObject<'_>` is not satisfied
+ --> tests/build/unsupported_from.rs:9:5
   |
 9 |     test: Test,
-  |           ^^^^ the trait `Clone` is not implemented for `Test`
+  |     ^^^^^^^^^^ the trait `Clone` is not implemented for `Test`, which is required by `Test: FromPyObject<'_>`
   |
   = help: the following other types implement trait `FromPyObject<'source>`:
-            <bool as FromPyObject<'source>>
-            <char as FromPyObject<'_>>
-            <isize as FromPyObject<'source>>
-            <i8 as FromPyObject<'source>>
-            <i16 as FromPyObject<'source>>
-            <i32 as FromPyObject<'source>>
-            <i64 as FromPyObject<'source>>
-            <i128 as FromPyObject<'source>>
+            <&'a PyCell<T> as FromPyObject<'a>>
+            <&'a [u8] as FromPyObject<'a>>
+            <&'py CancelledError as FromPyObject<'py>>
+            <&'py IncompleteReadError as FromPyObject<'py>>
+            <&'py InvalidStateError as FromPyObject<'py>>
+            <&'py LimitOverrunError as FromPyObject<'py>>
+            <&'py PanicException as FromPyObject<'py>>
+            <&'py PyAny as FromPyObject<'py>>
           and $N others
   = note: required for `Test` to implement `FromPyObject<'_>`
 note: required by a bound in `extract_required`

--- a/tests/build/unsupported_into.stderr
+++ b/tests/build/unsupported_into.stderr
@@ -8,12 +8,12 @@ error[E0277]: the trait bound `Test: IntoPy<Py<PyAny>>` is not satisfied
   |     the trait `IntoPy<Py<PyAny>>` is not implemented for `Test`
   |
   = help: the following other types implement trait `IntoPy<T>`:
-            <bool as IntoPy<Py<PyAny>>>
-            <char as IntoPy<Py<PyAny>>>
-            <isize as IntoPy<Py<PyAny>>>
-            <i8 as IntoPy<Py<PyAny>>>
-            <i16 as IntoPy<Py<PyAny>>>
-            <i32 as IntoPy<Py<PyAny>>>
-            <i64 as IntoPy<Py<PyAny>>>
-            <i128 as IntoPy<Py<PyAny>>>
+            <&'a OsString as IntoPy<Py<PyAny>>>
+            <&'a Path as IntoPy<Py<PyAny>>>
+            <&'a PathBuf as IntoPy<Py<PyAny>>>
+            <&'a PyErr as IntoPy<Py<PyAny>>>
+            <&'a String as IntoPy<Py<PyAny>>>
+            <&'a [u8] as IntoPy<Py<PyAny>>>
+            <&'a str as IntoPy<Py<PyAny>>>
+            <&'a str as IntoPy<Py<PyString>>>
           and $N others

--- a/tests/frompyobject.rs
+++ b/tests/frompyobject.rs
@@ -111,7 +111,7 @@ fn test_type_error() -> PyResult<()> {
         assert!(err.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
 
         let result = err.value(py).to_string();
-        assert_eq!(&result, "Unable to convert key: age");
+        assert_eq!(&result, "Unable to convert key: age. Error: TypeError: 'str' object cannot be interpreted as an integer");
         Ok(())
     })
 }


### PR DESCRIPTION
This PR makes the library display a more detailed error if `from` fails to convert the value.

Example:

Before:
```
"Unable to convert key: age"
```

After:
```
"Unable to convert key: age. Error: TypeError: 'str' object cannot be interpreted as an integer"
```

I had to run `TRYBUILD=overwrite cargo test` to make the tests pass. Doesn't seem like there is anything wrong with it. I am using the latest stable toolchain on `aarch64-apple-darwin`